### PR TITLE
feat: tgz the ubuntu files and create an empty deb

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,7 +7,7 @@ on:
   push:
 
 jobs:
-  windows:
+  cron:
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -25,19 +25,32 @@ NOTE: you have to keep a containing "chrome-version" folder with starting and en
 Mac distributions have had auto-updating removed. You should be able to copy the included `Google Chrome.app` files to directories on your computer.
 
 Updates have been removed by:
+
 - Updating `Contents/Info.plist` to a `localhost` url
 - Removing the code-signing signature from the binary so that Mac will be able to open the files.
 
 ### Linux
 
-Linux supports Debian and Ubuntu ".deb" files that can be installed with `apt -y install <path>`. Installers have had cron, user/desktop settings and apt updating removed. Each installer has also been modified to install at /opt/google/chrome/{version}/.
+Linux distributions have had desktop and auto-updating removed. The top level folder is the version of Chrome.
+
+#### Install Dependencies
+
+Inside each tar.gz, an "install-dependencies.deb" has been included. It's a debian installer that installs all the dependencies for the given version of chrome.
+
+Run: `apt -y install <path>/install-dependencies.deb`
+
+Chown: You may need to run `chown _apt {path to chrome}/install-dependencies.deb` to be able to run apt install.
+
+NOTE: Dependencies should be automatically resolved by apt. If this proves not to be the case, please share your experience!
+
+### Linux Side-by-Side Debian Installers
+
+Linux also includes Debian and Ubuntu ".deb" files that can be installed with `apt -y install <path>`. Installers have had cron, user/desktop settings and apt updating removed. Each installer has also been modified to install at /opt/google/chrome/{version}/.
 
 The debian package is also renamed to google-chrome-{version}, allowing you to install many side-by-side.
 
-Chown: You may need to run `chown _apt {path to installer.deb}` to be able to run apt install. 
+Chown: You may need to run `chown _apt {path to installer.deb}` to be able to run apt install.
 
-NOTE: Dependencies should be automatically resolved by apt. If this proves not to be the case, please share your experience!
- 
 ## Updating Versions
 
 This repository is checking for new Chrome versions from the Google update service daily at 10am. Those new versions are recorded in the versions.json file. NOTE: files are not downloaded until a new release or push is made against the repository.

--- a/scripts/checkChromeForUpdates.ts
+++ b/scripts/checkChromeForUpdates.ts
@@ -70,6 +70,7 @@ async function getChromeUpdateUrls(os: 'win' | 'mac', arch: 'x64' | 'x86' | 'arm
   if (osKey === 'mac') {
     Versions.set(version, {
       linux: `http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb`,
+      linux_rpm: `http://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${version}-1.x86_64.rpm`,
     });
   }
 }

--- a/scripts/debian/rebundleDeb.ts
+++ b/scripts/debian/rebundleDeb.ts
@@ -1,6 +1,7 @@
 import * as Fs from 'fs';
 import { mkTempDir } from '../dirUtils';
 import { execSync } from 'child_process';
+import { createTarGz } from '../createTarGz';
 
 /**
  * 1. Extract .deb
@@ -19,55 +20,75 @@ export default async function rebundleDeb(
   console.log('Modifying Chrome@%s', chromeVersion, downloadedDeb);
 
   console.log('dpkg -x', execSync(`dpkg -x "${downloadedDeb}" "${tmpDir}"`, { encoding: 'utf8' }));
-  console.log(
-    'dpkg -e',
-    execSync(`dpkg -e "${downloadedDeb}" "${tmpDir}/DEBIAN"`, { encoding: 'utf8' }),
-  );
 
   console.log('Listing extracted dirs', Fs.readdirSync(tmpDir));
   // remove cron
   console.log('Removing cron', `${tmpDir}/opt/google/chrome/cron`, `${tmpDir}/etc`);
   Fs.rmdirSync(`${tmpDir}/opt/google/chrome/cron`, { recursive: true });
-  Fs.rmdirSync(`${tmpDir}/etc`, { recursive: true });
-  console.log('Removing usr', `${tmpDir}/usr`);
-  Fs.rmdirSync(`${tmpDir}/usr`, { recursive: true });
+  console.log('Removing default app block');
+  Fs.unlinkSync(`${tmpDir}/opt/google/chrome/default-app-block`);
 
-  let appBlock = Fs.readFileSync(`${tmpDir}/opt/google/chrome/default-app-block`, 'utf8');
-  appBlock = appBlock.replace(/\/opt\/google\/chrome\//g, `/opt/google/chrome/${chromeVersion}/`);
-  appBlock = appBlock.replace(
-    '<name>Google Chrome</name>',
-    `<name>Google Chrome ${chromeVersion}</name>`,
-  );
-  console.log('Changing default-app-block to', appBlock);
-  Fs.writeFileSync(`${tmpDir}/opt/google/chrome/default-app-block`, appBlock, 'utf8');
-
+  // make new control file
+  const controlDir = mkTempDir();
   console.log(
-    `Moving '${tmpDir}/opt/google/chrome' -> '${tmpDir}/opt/google/chrome/${chromeVersion}'`,
+    'dpkg -e',
+    execSync(`dpkg -e "${downloadedDeb}" "${controlDir}/DEBIAN"`, { encoding: 'utf8' }),
   );
-  execSync(`mv "${tmpDir}/opt/google/chrome/" "${tmpDir}/opt/google/tmp/"`);
-  Fs.mkdirSync(`${tmpDir}/opt/google/chrome/`);
-  execSync(`mv "${tmpDir}/opt/google/tmp/" "${tmpDir}/opt/google/chrome/${chromeVersion}"`);
-
   // change control files
   console.log(
     'Removing control files',
-    `${tmpDir}/DEBIAN/postinst`,
-    `${tmpDir}/DEBIAN/postrm`,
-    `${tmpDir}/DEBIAN/prerm`,
+    `${controlDir}/DEBIAN/postinst`,
+    `${controlDir}/DEBIAN/postrm`,
+    `${controlDir}/DEBIAN/prerm`,
   );
-  Fs.unlinkSync(`${tmpDir}/DEBIAN/postinst`);
-  Fs.unlinkSync(`${tmpDir}/DEBIAN/postrm`);
-  Fs.unlinkSync(`${tmpDir}/DEBIAN/prerm`);
+  Fs.unlinkSync(`${controlDir}/DEBIAN/postinst`);
+  Fs.unlinkSync(`${controlDir}/DEBIAN/postrm`);
+  Fs.unlinkSync(`${controlDir}/DEBIAN/prerm`);
 
-  let control = Fs.readFileSync(`${tmpDir}/DEBIAN/control`, 'utf8');
-  control = control.replace(
-    'google-chrome-stable',
-    `google-chrome-${chromeVersion.replace(/\./g, '-')}`,
+  let control = Fs.readFileSync(`${controlDir}/DEBIAN/control`, 'utf8');
+  control = control
+    .replace('google-chrome-stable', `google-chrome-${chromeVersion.replace(/\./g, '-')}`)
+    .replace(/Maintainer: .+\n/, 'Maintainer: Data Liberation Foundation, Inc. <staff@dataliberationfoundation.org>')
+    .replace(/Installed-Size: .+\n/, '');
+
+  Fs.writeFileSync(`${controlDir}/DEBIAN/control`, control, 'utf8');
+
+  console.log(
+    'dpkg -b',
+    execSync(`dpkg -b "${controlDir}" "${tmpDir}/opt/google/chrome/install-dependencies.deb"`, {
+      encoding: 'utf8',
+    }),
   );
-  console.log('Changing control to', control);
-  Fs.writeFileSync(`${tmpDir}/DEBIAN/control`, control, 'utf8');
+  console.log(execSync(`ls -lart "${tmpDir}/opt/google/chrome/install-dependencies.deb"`));
 
-  console.log('dpkg -b', execSync(`dpkg -b "${tmpDir}" "${extractToPath}"`, { encoding: 'utf8' }));
-
+  Fs.renameSync(`${tmpDir}/opt/google/chrome`, `${tmpDir}/opt/google/${chromeVersion}`);
+  await createTarGz(extractToPath, `${tmpDir}/opt/google/`, [chromeVersion]);
   console.log(`${chromeVersion} for linux converted`);
 }
+
+/**
+ On Rhel, the rpm does this:
+
+ NSS_FILES="libnspr4.so.0d libplds4.so.0d libplc4.so.0d libssl3.so.1d \
+ libnss3.so.1d libsmime3.so.1d libnssutil3.so.1d"
+ LIBDIR=lib64
+
+ add_nss_symlinks() {
+
+  for f in $NSS_FILES
+  do
+    target=$(echo $f | sed 's/\.[01]d$//')
+    if [ -f "/$LIBDIR/$target" ]; then
+      ln -snf "/$LIBDIR/$target" "/opt/google/chrome/$f"
+    elif [ -f "/usr/$LIBDIR/$target" ]; then
+      ln -snf "/usr/$LIBDIR/$target" "/opt/google/chrome/$f"
+    else
+      echo $f not found in "/$LIBDIR/$target" or "/usr/$LIBDIR/$target".
+      exit 1
+    fi
+  done
+}
+
+ get requires: rpm -q --requires google-chrome-stable-$VERSION.x86_64.rpm
+
+ */

--- a/scripts/dirUtils.ts
+++ b/scripts/dirUtils.ts
@@ -27,7 +27,6 @@ export function mkTempDir(): string {
 }
 
 export function getAssetName(os: string, version: string): string {
-  if (os === 'linux') return `chrome_${version}_${os}.deb`;
   return `chrome_${version}_${os}.tar.gz`;
 }
 

--- a/scripts/syncVersions.ts
+++ b/scripts/syncVersions.ts
@@ -47,6 +47,7 @@ async function syncVersions() {
       if (!url && osToSync === 'linux') {
         Versions.set(version, {
           linux: `http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb`,
+          linux_rpm: `http://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${version}-1.x86_64.rpm`,
         });
         url = Versions.get(version);
       }

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,8 @@
     "mac": "http://dl.google.com/release2/chrome/DZO1z77P-o4EPbgGDajT9g_88.0.4324.182/GoogleChrome-88.0.4324.182.dmg",
     "linux": "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_88.0.4324.182-1_amd64.deb",
     "win32": "http://dl.google.com/release2/chrome/ZV9hBwuYvqc-xHWAW-DUUA_88.0.4324.182/88.0.4324.182_chrome_installer.exe",
-    "win64": "http://dl.google.com/release2/chrome/GEW4Ag12DUE6FGNtOxhhyQ_88.0.4324.182/88.0.4324.182_chrome_installer.exe"
+    "win64": "http://dl.google.com/release2/chrome/GEW4Ag12DUE6FGNtOxhhyQ_88.0.4324.182/88.0.4324.182_chrome_installer.exe",
+    "linux_rpm": "http://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-88.0.4324.182-1.x86_64.rpm"
   },
   "88.0.4324.150": {
     "mac_arm64": "http://dl.google.com/release2/chrome/ANBBqQiWFMQU-jDcc-pCqMA_88.0.4324.150/GoogleChrome-88.0.4324.150.dmg",


### PR DESCRIPTION
Changes debian to have a .tar.gz that exports all the files into a "version" folder, just like we do for windows.

As part of this, we create a new, empty ".deb" file that uses the Chrome installer dependencies, so you can get all dependencies for each version. That file lives inside the .tar.gz