### PR TITLE
Add linux_arm64 Chrome packaging for Docker/arm64

### DIFF
--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Synchronize Versions File
         run: node ./scripts/syncVersions.js
         env:
-          SYNC_OS_KEYS: linux
+          SYNC_OS_KEYS: linux,linux_arm64
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for Npm publish

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Updates have been removed by:
 
 Linux distributions have had desktop and auto-updating removed. The top level folder is the version of Chrome.
 
+Assets are published for:
+
+- `linux` — `linux/amd64` (Google `_amd64.deb`)
+- `linux_arm64` — `linux/arm64` (Google `_arm64.deb`, available for recent Chrome stables starting with the public linux-arm64 release on 2026-07-30 / Chrome 151+)
+
+`@ulixee/chrome-app` selects `linux_arm64` automatically when `process.arch === 'arm64'` on Linux.
+
 #### Install Dependencies
 
 Inside each tar.gz, an "install-dependencies.deb" has been included. It's a debian installer that installs all the dependencies for the given version of chrome.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "env": "env $(cat .env | xargs)",
     "mac": "npm run build && env $(cat .env | xargs) SYNC_OS_KEYS=mac,mac_arm64 SA_SHOW_REPLAY=false node ./scripts/syncVersions.js",
     "win": "npm run build && env $(cat .env | xargs) SYNC_OS_KEYS=win32,win64 SA_SHOW_REPLAY=false node ./scripts/syncVersions.js",
-    "linux": "npm run build && env $(cat .env | xargs) SYNC_OS_KEYS=linux SA_SHOW_REPLAY=false node ./scripts/syncVersions.js"
+    "linux": "npm run build && env $(cat .env | xargs) SYNC_OS_KEYS=linux,linux_arm64 SA_SHOW_REPLAY=false node ./scripts/syncVersions.js"
   },
   "dependencies": {
     "@actions/github": "^4.0.0",

--- a/packages/chrome-app/index.ts
+++ b/packages/chrome-app/index.ts
@@ -6,7 +6,7 @@ import { installChrome } from './lib/installChrome';
 
 const windowsLocalAppData = process.env.LOCALAPPDATA || Path.join(Os.homedir(), 'AppData', 'Local');
 
-type IPlatformName = 'linux' | 'mac' | 'mac_arm64' | 'win32' | 'win64';
+type IPlatformName = 'linux' | 'linux_arm64' | 'mac' | 'mac_arm64' | 'win32' | 'win64';
 
 export default class ChromeApp {
   public static aptScriptPath = `/tmp/apt-install-chrome-dependencies.sh`;
@@ -15,12 +15,14 @@ export default class ChromeApp {
     mac_arm64: Path.join('Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome'),
     mac: Path.join('Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome'),
     linux: 'chrome',
+    linux_arm64: 'chrome',
     win32: 'chrome.exe',
     win64: 'chrome.exe',
   };
 
   public static cacheDirectoryByPlatform = {
     linux: process.env.XDG_CACHE_HOME || Path.join(Os.homedir(), '.cache'),
+    linux_arm64: process.env.XDG_CACHE_HOME || Path.join(Os.homedir(), '.cache'),
     mac: Path.join(Os.homedir(), 'Library', 'Caches'),
     mac_arm64: Path.join(Os.homedir(), 'Library', 'Caches'),
     win32: windowsLocalAppData,
@@ -116,7 +118,10 @@ export default class ChromeApp {
       if (Os.arch() === 'arm64') return 'mac_arm64';
       return 'mac';
     }
-    if (osPlatformName === 'linux') return 'linux';
+    if (osPlatformName === 'linux') {
+      if (Os.arch() === 'arm64') return 'linux_arm64';
+      return 'linux';
+    }
     if (osPlatformName === 'win32') {
       if (Os.arch() === 'x64') return 'win64';
       return 'win32';

--- a/packages/chrome-app/lib/DependencyInstaller.ts
+++ b/packages/chrome-app/lib/DependencyInstaller.ts
@@ -13,7 +13,7 @@ export class DependencyInstaller {
     const platform = this.chromeApp.osPlatformName;
 
     const isWindows64 = platform === 'win64';
-    const isLinux = platform === 'linux';
+    const isLinux = platform === 'linux' || platform === 'linux_arm64';
 
     if (!isLinux && !isWindows64) return;
     if (await this.isValidated()) return;

--- a/packages/chrome-app/package.json
+++ b/packages/chrome-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulixee/chrome-app",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Chrome App driver",
   "license": "MIT",
   "repository": "git@github.com:ulixee/chrome-versions.git",

--- a/scripts/checkChromeForUpdates.ts
+++ b/scripts/checkChromeForUpdates.ts
@@ -194,8 +194,12 @@ async function getChromeUpdateUrlsLinux() {
   const versions = request.data;
   for (const entry of versions) {
     const version = entry.version;
+    // Google publishes linux-arm64 Chrome debs for recent stables (Chrome 151+ /
+    // publicly released 2026-07-30). Older versions return 404 and are cleared
+    // during syncVersions download.
     Versions.set(version, {
       linux: `http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb`,
+      linux_arm64: `http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_arm64.deb`,
       linux_rpm: `http://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${version}-1.x86_64.rpm`,
     });
   }

--- a/scripts/debian/index.ts
+++ b/scripts/debian/index.ts
@@ -16,9 +16,9 @@ export async function process(
     downloaded = await downloadInstaller(url, os, version);
   } catch (error) {
     if (String(error) === 'Not found' || error.response?.status === 404) {
+      // Only clear the missing OS key (e.g. linux_arm64 for older Chrome majors).
       Versions.set(version, {
-        linux: undefined,
-        linux_rpm: undefined,
+        [os]: undefined,
       });
     }
     console.log('Could not download file at %s', url);

--- a/scripts/dirUtils.ts
+++ b/scripts/dirUtils.ts
@@ -12,6 +12,7 @@ const fileExts = {
   mac: 'dmg',
   mac_arm64: 'dmg',
   linux: 'deb',
+  linux_arm64: 'deb',
 };
 
 export { downloadsDir, assetsDir };

--- a/scripts/syncVersions.ts
+++ b/scripts/syncVersions.ts
@@ -38,7 +38,7 @@ async function syncVersions() {
         await Windows.process(osToSync, version, releases);
       } else if (osToSync === 'mac' || osToSync === 'mac_arm64') {
         await Mac.process(osToSync, version, releases);
-      } else if (osToSync === 'linux') {
+      } else if (osToSync === 'linux' || osToSync === 'linux_arm64') {
         await Debian.process(osToSync, version, releases);
       }
     }


### PR DESCRIPTION
## Summary
- Add `linux_arm64` as a first-class platform alongside `linux` (amd64).
- Record Google `_arm64.deb` URLs in the Linux update check (available for recent stables; older majors 404 and are cleared per-OS during sync).
- Sync/rebundle arm64 debs to `chrome_<ver>_linux_arm64.tar.gz` and upload release assets.
- Update `@ulixee/chrome-app` (1.0.5) so Linux `arm64` hosts download `linux_arm64` assets instead of the amd64 `linux` tarball.
- Fix Debian 404 handling to clear only the missing OS key (do not wipe amd64 when arm64 is absent).

## Why
Google publicly released Chrome for linux-arm64 on 2026-07-30 (see https://issues.chromium.org/issues/374811603). Cypress and others are adding arm64 Chrome Docker support; Ulixee Cloud images need matching chrome-versions assets first.

## Test plan
- [x] `yarn build` succeeds
- [x] Downloaded `google-chrome-stable_151.0.7922.75-1_arm64.deb` and ran `rebundleDeb`
- [x] Produced `chrome_151.0.7922.75_linux_arm64.tar.gz`
- [x] Extracted `chrome` binary is `ELF 64-bit LSB pie executable, ARM aarch64`

## Follow-ups
- Publish `@ulixee/chrome-app@1.0.5` after merge so consumers pick up platform detection.
- Sync workflow will publish `linux_arm64` assets for Chrome versions Google still hosts as arm64 debs (typically 151+).
- Hero/Cloud still need a Chrome major with arm64 binaries before `ulixee-cloud` arm64 images are fully usable end-to-end.